### PR TITLE
CLOSES #7: Replaces deprecated Dockerfile MAINTANER with a LABEL equivalent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Summary of release changes.
 
 Caddy - The HTTP/2 web server with automatic HTTPS.
 
+## 1.1.1 - Unreleased
+
+- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL` equivalent.
+
 ## 1.1.0 - 2017-05-14
 
 - Updates Caddy to version 0.10.2. 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@
 # =============================================================================
 FROM scratch
 
-MAINTAINER James Deathe <james.deathe@gmail.com>
-
 COPY src /
 
 EXPOSE 2015 8080 8443
@@ -23,6 +21,7 @@ ENV CADDY_VERSION="0.10.2" \
 # -----------------------------------------------------------------------------
 ARG RELEASE_VERSION="1.1.0"
 LABEL \
+	maintainer="James Deathe <james.deathe@gmail.com>" \
 	install="\
 docker run -d \ 
 --name \${NAME} \


### PR DESCRIPTION
Resolves #7 

- Replaces deprecated Dockerfile MAINTANER with a LABEL equivalent.