### PR TITLE
Release changes for 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Summary of release changes.
 
 Caddy - The HTTP/2 web server with automatic HTTPS.
 
-## 1.1.1 - Unreleased
+## 1.2.0 - Unreleased
 
+- Updates Caddy to versoin 0.10.6.
 - Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL` equivalent.
 
 ## 1.1.0 - 2017-05-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Caddy - The HTTP/2 web server with automatic HTTPS.
 
 ## 1.2.0 - Unreleased
 
-- Updates Caddy to versoin 0.10.6.
+- Updates Caddy to version 0.10.6.
 - Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL` equivalent.
 - Adds `STARTUP_TIME` variable for the `logs-delayed` Makefile target.
 - Adds test case output with improved readability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Caddy - The HTTP/2 web server with automatic HTTPS.
 
 - Updates Caddy to versoin 0.10.6.
 - Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL` equivalent.
+- Adds `STARTUP_TIME` variable for the `logs-delayed` Makefile target.
 
 ## 1.1.0 - 2017-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Caddy - The HTTP/2 web server with automatic HTTPS.
 - Updates Caddy to versoin 0.10.6.
 - Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL` equivalent.
 - Adds `STARTUP_TIME` variable for the `logs-delayed` Makefile target.
+- Adds test case output with improved readability.
 
 ## 1.1.0 - 2017-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Summary of release changes.
 
 Caddy - The HTTP/2 web server with automatic HTTPS.
 
+## 1.1.1 - Unreleased
+
+- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL` equivalent.
+
 ## 1.1.0 - 2017-05-14
 
 - Updates Caddy to version 0.10.2. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Summary of release changes.
 
 Caddy - The HTTP/2 web server with automatic HTTPS.
 
-## 1.2.0 - Unreleased
+## 1.2.0 - 2017-08-12
 
 - Updates Caddy to version 0.10.6.
 - Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL` equivalent.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@
 # =============================================================================
 FROM scratch
 
-MAINTAINER James Deathe <james.deathe@gmail.com>
-
 COPY src /
 
 EXPOSE 2015 8080 8443
@@ -23,6 +21,7 @@ ENV CADDY_VERSION="0.10.2" \
 # -----------------------------------------------------------------------------
 ARG RELEASE_VERSION="1.1.0"
 LABEL \
+	maintainer="James Deathe <james.deathe@gmail.com>" \
 	install="\
 docker run -d \ 
 --name \${NAME} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ EXPOSE 2015 8080 8443
 # -----------------------------------------------------------------------------
 # Set default environment variables used to configure the service container
 # -----------------------------------------------------------------------------
-ENV CADDY_VERSION="0.10.2" \
+ENV CADDY_VERSION="0.10.6" \
 	CADDYPATH="/var/caddy" \
 	CASE_SENSITIVE_PATH=true
 
 # -----------------------------------------------------------------------------
 # Set image metadata
 # -----------------------------------------------------------------------------
-ARG RELEASE_VERSION="1.1.0"
+ARG RELEASE_VERSION="1.2.0"
 LABEL \
 	maintainer="James Deathe <james.deathe@gmail.com>" \
 	install="\

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ Targets:
                             DOCKER_IMAGE_TAG variable.
   logs                      Display log output from the running container.
   logs-delayed              Display log output from the running container after
-                            backing off shortly. This can be necessary when 
-                            chaining make targets together.
+                            backing off for STARTUP_TIME seconds. This can be 
+                            necessary when chaining make targets together.
   pause                     Pause the running container.
   pull                      Pull the release image from the registry. Requires 
                             the DOCKER_IMAGE_TAG variable.
@@ -61,6 +61,9 @@ Variables:
                             artifacts are placed.
   - NO_CACHE                When true, no cache will be used while running the 
                             build target.
+  - STARTUP_TIME            Defines the number of seconds expected to complete 
+                            the startup process, including the bootstrap where 
+                            applicable.
 
 endef
 
@@ -357,7 +360,7 @@ logs: _prerequisites
 	@ $(docker) logs $(DOCKER_NAME)
 
 logs-delayed: _prerequisites
-	@ sleep 2
+	@ sleep $(STARTUP_TIME)
 	@ $(MAKE) logs
 
 load: _prerequisites _require-docker-release-tag _require-package-path

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@
 
 ### Tags and respective `Dockerfile` links
 
-- `1.1.0` [(master/Dockerfile)](https://github.com/jdeathe/image-caddy/blob/master/Dockerfile)
+- `1.2.0` [(master/Dockerfile)](https://github.com/jdeathe/image-caddy/blob/master/Dockerfile)
 
 ## Quick Example
 
 ```
-$ docker run -d \
+$ docker run \
+  --detach \
   --name caddy_1 \
   --restart always \
   --publish 443:2015 \
   --publish 80:8080 \
-  jdeathe/caddy:1.1.0
+  jdeathe/caddy:1.2.0
 ```
 
 Now point your browser to `http://{docker-host}` where `{docker-host}` is the host name of your docker server and, if all went well, you should be redirected to the `https://{docker-host}` and, after accepting the warning about the automatically generated self-signed TLS/SSL certificate, see the "Hello, world!" page.

--- a/docker-compose-php.yml
+++ b/docker-compose-php.yml
@@ -29,7 +29,7 @@ services:
     command: ["-conf", "/etc/caddy/Caddyfile-php", "-quiet=true"]
     depends_on:
       - "php71_fpm"
-    image: "jdeathe/caddy:1.1.0"
+    image: "jdeathe/caddy:1.2.0"
     links:
       - "php71_fpm"
     networks:

--- a/docker-compose-php.yml
+++ b/docker-compose-php.yml
@@ -3,9 +3,7 @@
 # 
 # docker-compose -f docker-compose-php.yml -p caddyphp1 down
 # 
-# docker-compose -f docker-compose-php.yml -p caddyphp1 up -d
-# docker-compose -f docker-compose-php.yml -p caddyphp1 scale php71_fpm=2
-# docker-compose -f docker-compose-php.yml -p caddyphp1 up -d --force-recreate --no-deps caddy
+# docker-compose -f docker-compose-php.yml -p caddyphp1 up -d --scale php71_fpm=2
 #
 # Known Issues:
 # Use of a named data volume is necessary to share the application directory 
@@ -43,7 +41,7 @@ services:
   php71_fpm:
     group_add:
       - "497"
-    image: "php:7.1.1-fpm-alpine"
+    image: "php:7.1.8-fpm-alpine"
     networks:
       php_fpm:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@
 version: "2"
 services:
   caddy:
-    image: "jdeathe/caddy:1.1.0"
+    image: "jdeathe/caddy:1.2.0"
     ports:
       - "80:8080"
       - "443:2015"

--- a/environment.mk
+++ b/environment.mk
@@ -28,6 +28,9 @@ NO_CACHE ?= false
 # Directory path for release packages
 DIST_PATH ?= ./dist
 
+# Number of seconds expected to complete container startup including bootstrap.
+STARTUP_TIME ?= 1
+
 # ------------------------------------------------------------------------------
 # Application container configuration
 # ------------------------------------------------------------------------------

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1,4 +1,4 @@
-readonly BOOTSTRAP_BACKOFF_TIME=1
+readonly STARTUP_TIME=1
 readonly TEST_DIRECTORY="test"
 
 # These should ideally be a static value but hosts might be using this port so 
@@ -57,7 +57,7 @@ function test_basic_operations ()
 				jdeathe/caddy:latest \
 			&> /dev/null
 
-			sleep ${BOOTSTRAP_BACKOFF_TIME}
+			sleep ${STARTUP_TIME}
 
 			container_running_id="$(
 				docker ps \


### PR DESCRIPTION
- Updates Caddy to version 0.10.6.
- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL` equivalent.
- Adds `STARTUP_TIME` variable for the `logs-delayed` Makefile target.
- Adds test case output with improved readability.